### PR TITLE
added support for new onSuccessLoadStore1MS

### DIFF
--- a/filter.js
+++ b/filter.js
@@ -2,8 +2,9 @@
   "use strict";
   if (typeof omsOnInit === 'function') {
     omsOnInit(function() {
-      require(['oms/ecommerce/product-filter', 'oms/translations'], function(ProductFilter, translations) {
+      require(['oms/ecommerce/product-filter', 'oms/translations','oms/ecommerce/store'], function(ProductFilter, translations) {
         doWork(ProductFilter, translations);
+        onSuccessLoadStore1MS();
       });
     });
   }

--- a/filter_afi.js
+++ b/filter_afi.js
@@ -3,8 +3,9 @@
 
   if (typeof omsOnInit === 'function') {
     omsOnInit(function() {
-      require(['oms/ecommerce/product-filter', 'oms/translations'], function(ProductFilter, translations) {
+      require(['oms/ecommerce/product-filter', 'oms/translations','oms/ecommerce/store'], function(ProductFilter, translations) {
         doWork(ProductFilter, translations);
+        onSuccessLoadStore1MS();
       });
     });
   }

--- a/filter_template.js
+++ b/filter_template.js
@@ -2,8 +2,9 @@
   "use strict";
   if (typeof omsOnInit === 'function') {
     omsOnInit(function() {
-      require(['oms/ecommerce/product-filter', 'oms/translations'], function(ProductFilter, translations) {
+      require(['oms/ecommerce/product-filter', 'oms/translations','oms/ecommerce/store'], function(ProductFilter, translations) {
         doWork(ProductFilter, translations);
+        onSuccessLoadStore1MS();
       });
     });
   }


### PR DESCRIPTION
The onSuccessLoadStore1MS now requires to be included inside the omsOnInit function when the JS is included in the footer of the page.
